### PR TITLE
Add EEPROM calibration storage

### DIFF
--- a/30 Remote Control/Remote Control.md
+++ b/30 Remote Control/Remote Control.md
@@ -13,6 +13,9 @@ VCC : 3.3v <br />
 Speed : VP (39) <br />
 Angle : VN (36) <br />
 
+**Recalibration** <br />
+To recalibrate: connect pin 27 (unless redefined in RECALIBRATION_PIN) to ground. 
+
 ---
 
 ## JSON Structure

--- a/30 Remote Control/Remote Control.md
+++ b/30 Remote Control/Remote Control.md
@@ -32,11 +32,11 @@ To recalibrate: connect pin 27 (unless redefined in RECALIBRATION_PIN) to ground
 * JSON Packing (See above *'Json Structure'*)
 * ESP-NOW master, connects to slave (Controller ESP) and sends the json formatted data. (See above *'Json Structure'*)
 * OLED Output of speed and angle data, also instructions for joystick calibration.
-
-## Upcoming Features (Short Term / V1)
 * Calibration data stored in EEPROM
 * Calibration verification
-* Display robot and remote controller battery status.
+
+## Upcoming Features (Short Term / V1)
+* Display robot and remote controller battery status. *(waiting for battery decision)*
 
 ## Future Additions
 * Second Joystick:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A "globalDefinitions.h file is in the Misc directory. It has to be copied to the
     * Moving forward, the remote controller will have another joystick, and have a nice 3D printed case.
 * A small OLED will be integrated into the remote controller:
     * Display Speed / Angle values (**completed**: displays values selected by joystick)
-    * Display RoboTank and remote controller battery voltages
+    * Display RoboTank and remote controller battery voltages *(Waiting for battery decision)*
     * Display calibration prompts (**completed**)
     * *Display a menu system for different features of the tank. (**long term**)*
 


### PR DESCRIPTION
Calibration should take place only on first boot, values are then stored
in EEPROM. Calibration can be then only be triggered with a physical
connection.

Updated documentation to reflect changes.